### PR TITLE
Don't redirect if no url is provided

### DIFF
--- a/api/[base]/[table]/index.js
+++ b/api/[base]/[table]/index.js
@@ -12,9 +12,12 @@ export default async function handler(req, res) {
   const returnedByAirtable = await airtable.create(req.body);
   
   try {
-    res.writeHead(302, { Location: req.query.redirect }).end();
-  }
-  catch {
+    if (req.query.redirect) {
+      res.writeHead(302, { Location: req.query.redirect }).end();
+    } else {
+      res.status(204).end();
+    }
+  } catch {
     res.json(returnedByAirtable);
   }
 }


### PR DESCRIPTION
When no redirect url is provided, it returns with status code 204 (No Content) rather than attempting to redirect.

Makes this code a tad bit cleaner:
https://github.com/hackclub/bank/blob/44baabd03c1ca07b9f25a0f5a84fbff2673b8d47/app/services/partnered_signup_service/sync_to_airtable.rb#L18-L19